### PR TITLE
La til tensorflow 2.2.0 i requirements

### DIFF
--- a/jupyterhub/requirements.txt
+++ b/jupyterhub/requirements.txt
@@ -50,6 +50,7 @@ scikit-learn==0.21.2
 sklearn-crfsuite==0.3.6
 spacy==2.3.0
 torch==1.6.0
+tensorflow==2.2.0
 transformers==3.0.2
 vega==2.6.0
 vega-datasets==0.7.0


### PR DESCRIPTION
Har noe kode tryner i jupyterhub men funker i kubeflow, tror det kan skyldes versjonen på tensorflow.
(det kan hende at nyere versjoner av tf også vil funke, men satte 2.2.0 siden det var det vi hadde på kubeflow)