### PR TITLE
add researchpy for chisquare mcnemar gtest and fisher tests

### DIFF
--- a/jupyterhub/requirements.txt
+++ b/jupyterhub/requirements.txt
@@ -53,6 +53,7 @@ pyLDAvis>=2.1.2
 pyodbc>=4.0.30
 pysftp>=0.2.9
 ray[default]
+researchpy==0.3.2
 s3-prd-crypt>=0.0.2
 salesforce-api>=0.1.45
 scattertext>=0.1.4


### PR DESCRIPTION
Added [researchpy](https://researchpy.readthedocs.io/en/latest/) for chi square, McNemar, g test and Fisher tests in python