### PR TITLE
bump airflow base image to 2.9.3-python3.11 (default for chart versio…

### DIFF
--- a/.github/workflows/airflow.yaml
+++ b/.github/workflows/airflow.yaml
@@ -14,7 +14,7 @@ on:
     - cron: "0 9 * * *"
 
 env:
-  BASE_IMAGE_TAG: 2.8.3-python3.11
+  BASE_IMAGE_TAG: 2.9.3-python3.11
   IMAGE: airflow
 
 permissions:


### PR DESCRIPTION
…n 1.15.0)