### PR TITLE
Change image tagging from YYYY-MM-DD-SHA256 to YYYYMMDD-SHA256

### DIFF
--- a/.github/workflows/airflow.yaml
+++ b/.github/workflows/airflow.yaml
@@ -67,7 +67,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo "TAG=$(git log -1 --pretty=%ad --date=format:%Y-%m-%d)-$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_ENV
+      - run: echo "TAG=$(git log -1 --pretty=%ad --date=format:%Y%m%d)-$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_ENV
 
       - uses: docker/build-push-action@v5
         if: env.OUTDATED == 'true' || contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)

--- a/.github/workflows/dataverk-airflow.yaml
+++ b/.github/workflows/dataverk-airflow.yaml
@@ -69,7 +69,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo "TAG=$(git log -1 --pretty=%ad --date=format:%Y-%m-%d)-$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_ENV
+      - run: echo "TAG=$(git log -1 --pretty=%ad --date=format:%Y%m%d)-$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_ENV
 
       - uses: docker/build-push-action@v5
         if: env.OUTDATED == 'true' || contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)

--- a/.github/workflows/jupyter.yaml
+++ b/.github/workflows/jupyter.yaml
@@ -56,7 +56,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo "TAG=$(git log -1 --pretty=%ad --date=format:%Y-%m-%d)-$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_ENV
+      - run: echo "TAG=$(git log -1 --pretty=%ad --date=format:%Y%m%d)-$(git log --pretty=format:'%h' -n 1)" >> $GITHUB_ENV
 
       - uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
With the current tagging schema, downstream dependencies that use dependabot will not get pull requests on updates. Dependabot does not recognize newer tags and will always claim that the current tag is the newest.